### PR TITLE
Create Let the webinterface show 'alias' instead of 'host_name'.

### DIFF
--- a/Let the webinterface show 'alias' instead of 'host_name'.
+++ b/Let the webinterface show 'alias' instead of 'host_name'.
@@ -1,0 +1,13 @@
+First off, sorry if I'm doing this wrong. 
+
+As stated in the title, why not let the webinterface show the 'alias' name instead of the 'host_name'? 
+This way, you only have to write down the long name once instead of several times, depending on the amount of services. I tried
+messing with the PHP code but my PHP knowledge isn't good enough.
+
+I posted this question in the vshell support forum and I got redirected here. 
+
+I hope I provided enough information, if not I'm sure you can contact me somehow. 
+
+Thanks for your time,
+
+-Tycser


### PR DESCRIPTION
First off, sorry if I'm doing this wrong. 

As stated in the title, why not let the webinterface show the 'alias' name instead of the 'host_name'? 
This way, you only have to write down the long name once instead of several times, depending on the amount of services. I tried
messing with the PHP code but my PHP knowledge isn't good enough.

I posted this question in the vshell support forum and I got redirected here. 

I hope I provided enough information, if not I'm sure you can contact me somehow. 

Thanks for your time,

-Tycser