### PR TITLE
Add ‘Long Plugin Output’ in Service Detail display page

### DIFF
--- a/www/data/process_details.php
+++ b/www/data/process_details.php
@@ -90,6 +90,7 @@ function process_service_detail($serviceid)
 					'Service' => $sd['service_description'],
 					'Host'	  => $hostname,
 					'Output'  => $sd['plugin_output'],
+					'LongOutput'  => $sd['long_plugin_output'],
 					'MemberOf' => $membership,
 					'CheckCommand' => $sd['check_command'],
 					'State' => $current_state,

--- a/www/views/servicedetails.php
+++ b/www/views/servicedetails.php
@@ -75,6 +75,7 @@ function get_service_details($dets)
 		
 	$page.="	
 		<tr><td>".gettext('Plugin Output')."</td><td><div class='td_maxwidth'>{$dets['Output']}</div></td></tr>
+		<tr><td>".gettext('Long Plugin Output')."</td><td><div class='td_maxwidth'>{$dets['LongOutput']}</div></td></tr>
 		<tr><td>".gettext('Duration')."</td><td>{$dets['Duration']}</td></tr>
 		<tr><td>".gettext('State Type')."</td><td>{$dets['StateType']}</td></tr>
 		<tr><td>".gettext('Current Check')."</td><td>{$dets['CurrentCheck']}</td></tr>


### PR DESCRIPTION
Results from nrpe or other agents will be splitted into plugin_output and long_plugin_output.
plugin_output mainly used as summary message and details stored in object long_plugin_outout.